### PR TITLE
cloudflare-ddns: update security settings

### DIFF
--- a/cloudflare-ddns/docker-compose.yml
+++ b/cloudflare-ddns/docker-compose.yml
@@ -5,11 +5,6 @@ services:
     network_mode: host
     # This makes IPv6 easier; see below
     restart: unless-stopped
-    cap_add:
-        # Capability to change user ID; needed for using PUID
-      - SETUID
-        # Capability to change group ID; needed for using PGID
-      - SETGID
     cap_drop:
       # Drop all other capabilities
       - all


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.